### PR TITLE
Fix error when removing the entire map

### DIFF
--- a/lib/react-leaflet-googlemutant.js
+++ b/lib/react-leaflet-googlemutant.js
@@ -413,8 +413,10 @@ L.GridLayer.GoogleMutant = L.GridLayer.extend({
 		map.off('zoomend', this._handleZoomAnim, this);
 		map.off('resize', this._resize, this);
 
-		map._controlCorners.bottomright.style.marginBottom = '0em';
-		map._controlCorners.bottomleft.style.marginBottom = '0em';
+		if(map._controlCorners) {
+			map._controlCorners.bottomright.style.marginBottom = '0em';
+			map._controlCorners.bottomleft.style.marginBottom = '0em';
+		}
 	},
 
 	getAttribution: function () {


### PR DESCRIPTION
Hello,
When we are unmounting the component map we get this error:
`Uncaught TypeError: Cannot read property 'bottomright' of undefined
    at NewClass.onRemove (react-leaflet-googlemutant.js:417)
    at NewClass.removeLayer (leaflet-src.js:6476)
    at NewClass.removeFrom (leaflet-src.js:6357)
    at NewClass.remove (leaflet-src.js:6350)
    at NewClass.remove (leaflet-src.js:3640)
    at Map.componentWillUnmount (Map.js:182)
    at ReactCompositeComponent.js:406
    at measureLifeCyclePerf (ReactCompositeComponent.js:73)`
In this pull request you can find the fix :) 